### PR TITLE
Add Data Dispatcher functionality

### DIFF
--- a/AFL/automation/APIServer/APIServer.py
+++ b/AFL/automation/APIServer/APIServer.py
@@ -42,12 +42,13 @@ except ImportError:
     warnings.warn('Plotting imports failed! Live data plotting will not work on this server.',stacklevel=2)
 
 class APIServer:
-    def __init__(self,name,experiment='Development',contact='tbm@nist.gov',index_template='index.html',plot_template='simple-bokeh.html'):
+    def __init__(self,name,data = None,experiment='Development',contact='tbm@nist.gov',index_template='index.html',plot_template='simple-bokeh.html'):
         self.name = name
         self.experiment = experiment
         self.contact = contact
         self.index_template = index_template
         self.plot_template = plot_template
+        self.data = data
 
         self.logger_filter= LoggerFilter('get_queue','queue_state','driver_status','get_server_time','get_info')
 
@@ -69,8 +70,9 @@ class APIServer:
         self.task_queue = MutableQueue()
         self.driver     = driver
         self.driver.app = self.app
+        self.driver.data = self.data
         self.driver._queue = self.task_queue
-        self.queue_daemon = QueueDaemon(self.app,driver,self.task_queue,self.history)
+        self.queue_daemon = QueueDaemon(self.app,driver,self.task_queue,self.history,data = self.data)
 
         self.add_unqueued_routes()
 

--- a/AFL/automation/APIServer/Driver.py
+++ b/AFL/automation/APIServer/Driver.py
@@ -41,9 +41,9 @@ class Driver:
     unqueued = makeRegistrar()
     queued = makeRegistrar()
     quickbar = makeRegistrar()
-    def __init__(self,name,defaults=None,overrides=None,data=None):
+    def __init__(self,name,defaults=None,overrides=None):
         self.app = None
-        self.data = data
+        self.data = None
         if name is None:
             self.name = 'Driver'
         else:

--- a/AFL/automation/APIServer/Driver.py
+++ b/AFL/automation/APIServer/Driver.py
@@ -41,9 +41,9 @@ class Driver:
     unqueued = makeRegistrar()
     queued = makeRegistrar()
     quickbar = makeRegistrar()
-    def __init__(self,name,defaults=None,overrides=None):
+    def __init__(self,name,defaults=None,overrides=None,data=None):
         self.app = None
-        self.data = None
+        self.data = data
         if name is None:
             self.name = 'Driver'
         else:

--- a/AFL/automation/APIServer/Driver.py
+++ b/AFL/automation/APIServer/Driver.py
@@ -4,6 +4,7 @@ from AFL.automation.shared import serialization
 from math import ceil,sqrt
 import inspect 
 import pathlib
+import uuid
 
 def makeRegistrar():
     functions = []
@@ -42,6 +43,7 @@ class Driver:
     quickbar = makeRegistrar()
     def __init__(self,name,defaults=None,overrides=None):
         self.app = None
+        self.data = None
         if name is None:
             self.name = 'Driver'
         else:
@@ -117,7 +119,22 @@ class Driver:
             for name,value in config:
                 print(f'{name:30s} = {value}')
         return config.config
-        
+    
+    def set_sample(self,sample_name,sample_uuid=None,**kwargs):
+        if sample_uuid is None:
+            sample_uuid = str(uuid.uuid4())
+
+        kwargs.update({'sample_name':sample_name,'sample_uuid':sample_uuid})
+        self.data.update(kwargs)
+
+        return kwargs
+
+    def get_sample(self):
+        return self.data._sample_dict
+
+    def reset_sample(self):
+        self.data.reset_sample()
+
     def status(self):
         status = []
         return status
@@ -172,5 +189,19 @@ class Driver:
             value = serialization.serialize(value)
         return value
 
+    def set_data(self,data: dict):
+        '''Set data in the DataPacket object
 
-   
+        Parameters
+        ----------
+        data : dict
+            Dictionary of data to store in the driver object
+        
+        Note! if the keys in data are not system or sample variables,
+        they will be erased at the end of this function call.
+        
+
+        '''
+        for name,value in data.items():
+            self.app.logger.info(f'Setting data \'{name}\'')
+            self.data.update(data)

--- a/AFL/automation/APIServer/DummyDriver.py
+++ b/AFL/automation/APIServer/DummyDriver.py
@@ -21,7 +21,7 @@ class DummyDriver(Driver):
         status.append('Selectors: selecting')
         status.append('Neutrons: scattering')
         return status
-
+    '''
     def execute(self,**kwargs):
         if self.app is not None:
             self.app.logger.debug(f'Executing task {kwargs}')
@@ -34,7 +34,7 @@ class DummyDriver(Driver):
                 del kwargs['task_name']
                 return_val = getattr(self,task_name)(**kwargs)
                 return return_val
-
+    '''
     @Driver.queued()
     def test_command1(self,kwarg1=None,kwarg2=True):
         '''A test command with positional and keyword parameters'''
@@ -44,7 +44,14 @@ class DummyDriver(Driver):
     def test_command2(self,kwarg1=False,kwarg2=False,kwarg3=True):
         '''A test command with positional and keyword parameters'''
         pass
-
+    @Driver.queued()
+    def test_command_sets_data(self,kwarg1=False,kwarg2=False,kwarg3=True):
+        '''A test command with positional and keyword parameters'''
+        if self.data is not None:
+            self.data['kwarg1'] = kwarg1
+            self.data['kwarg2'] = kwarg2
+            self.data['kwarg3'] = kwarg3
+        return np.random.randn(10)
     @Driver.unqueued()
     def how_many(self,**kwargs):
         self.app.logger.debug(f'Call to how_many with kwargs: {kwargs}')

--- a/AFL/automation/APIServer/data/DataJSON.py
+++ b/AFL/automation/APIServer/data/DataJSON.py
@@ -12,6 +12,7 @@ class DataJSON(DataPacket):
         self.path = path
         super().__init__()
     def transmit(self):
+        self._sanitize()
         filename = str(datetime.datetime.now()).replace(' ','-')
         with open(f'{self.path}/{filename}.json','w') as f:
             json.dump(self._dict(),f)

--- a/AFL/automation/APIServer/data/DataJSON.py
+++ b/AFL/automation/APIServer/data/DataJSON.py
@@ -1,0 +1,19 @@
+from .DataPacket import DataPacket
+import datetime
+import json
+import os
+
+class DataJSON(DataPacket):
+    '''
+      A DataPacket implementation that serializes its data to JSON, named according to the current time.
+    '''
+
+    def __init__(self,path):
+        self.path = path
+        super().__init__()
+    def transmitData(self):
+        filename = str(datetime.datetime.now()).replace(' ','-')
+        os.chdir(self.path)
+        with open(f'{filename}.json','w') as f:
+            json.dump(self._dict(),f)
+

--- a/AFL/automation/APIServer/data/DataJSON.py
+++ b/AFL/automation/APIServer/data/DataJSON.py
@@ -13,7 +13,6 @@ class DataJSON(DataPacket):
         super().__init__()
     def transmitData(self):
         filename = str(datetime.datetime.now()).replace(' ','-')
-        os.chdir(self.path)
-        with open(f'{filename}.json','w') as f:
+        with open(f'{self.path}/{filename}.json','w') as f:
             json.dump(self._dict(),f)
 

--- a/AFL/automation/APIServer/data/DataJSON.py
+++ b/AFL/automation/APIServer/data/DataJSON.py
@@ -11,8 +11,10 @@ class DataJSON(DataPacket):
     def __init__(self,path):
         self.path = path
         super().__init__()
-    def transmitData(self):
+    def transmit(self):
         filename = str(datetime.datetime.now()).replace(' ','-')
         with open(f'{self.path}/{filename}.json','w') as f:
             json.dump(self._dict(),f)
-
+    def finalize(self):
+        self.transmit()
+        self.reset()

--- a/AFL/automation/APIServer/data/DataPacket.py
+++ b/AFL/automation/APIServer/data/DataPacket.py
@@ -38,6 +38,15 @@ class DataPacket:
         else:
             self._transient_dict[key] = value
     
+    def _dict(self):
+        ''' 
+        returns a single dictionary that contains all values stored in data.
+        
+        N.B.: this dict is a deepcopy of the internal structures, so it cannot be written to - or at least, if it is, those writes will be lost.
+        
+        '''
+        return copy.deepcopy(self._transient_dict).update(self._sample_dict).update(self._system_dict)
+        
     def resetClass(self):
         self._transient_dict = {}
         
@@ -46,7 +55,8 @@ class DataPacket:
         pass
         
     def finalizeData(self):
-        raise NotImplementedError
+        self.transmitData()
+        self.resetClass()
         
     def transmitData(self):
         raise NotImplementedError

--- a/AFL/automation/APIServer/data/DataPacket.py
+++ b/AFL/automation/APIServer/data/DataPacket.py
@@ -2,6 +2,17 @@ import copy
 from collections.abc import MutableMapping
 
 class DataPacket(MutableMapping):
+    '''
+    A DataPacket is a container for data that is to be transmitted to a data store.
+
+    It is a dictionary-like object that stores data in three different ways:
+    - transient data, which is cleared on resets
+    - system data, which is never cleared
+    - sample data, which is cleared only on specific resets of the sample
+
+    The data is transmitted to the data store on finalization, which is called at the end of each method.
+    '''
+
     
     PROTECTED_SYSTEM_KEYS = [
         'driver_name',
@@ -66,6 +77,9 @@ class DataPacket(MutableMapping):
         retval.update(self._system_dict)
         return retval
     def reset(self):
+        '''
+        Clears all transient data.
+        '''
         self._transient_dict = {}
     
     def keys(self):

--- a/AFL/automation/APIServer/data/DataPacket.py
+++ b/AFL/automation/APIServer/data/DataPacket.py
@@ -1,0 +1,19 @@
+class DataPacket:
+
+    def __init__(self):
+        self._dict = {}
+        
+        
+    def __getitem__(self,key):
+        return self._dict[key]
+    
+    def __setitem__(self,key,value):
+        self._dict[key] = value
+    
+    def setupDefaults(self):
+   
+    def finalizeData(self):
+        raise NotImplementedError
+        
+    def transmitData(self):
+        raise NotImplementedError

--- a/AFL/automation/APIServer/data/DataPacket.py
+++ b/AFL/automation/APIServer/data/DataPacket.py
@@ -1,17 +1,50 @@
 class DataPacket:
-
-    def __init__(self):
-        self._dict = {}
+    
+    PROTECTED_SYSTEM_KEYS = [
+        'driver_name',
+        'driver_config',
+        'platform_serial',
         
+        
+    
+    ]
+    PROTECTED_SAMPLE_KEYS = [
+        'sample_name',
+        'sample_uuid',
+        'sample_composition',
+        'sample_al_components',
+        
+    
+    ]
+    
+    def __init__(self):
+        self._transient_dict = {}
+        self._system_dict = {}
+        self._sample_dict = {}
         
     def __getitem__(self,key):
-        return self._dict[key]
+        if key in self._system_dict.keys():
+            return self._system_dict[key]
+        elif key in self._sample_dict.keys():
+            return self._sample_dict[key]
+        else:
+            return self._transient_dict[key]
     
     def __setitem__(self,key,value):
-        self._dict[key] = value
+        if key in PROTECTED_SYSTEM_KEYS:
+            self._system_dict[key] = value
+        elif key in PROTECTED_SAMPLE_KEYS:
+            self._sample_dict[key] = value
+        else:
+            self._transient_dict[key] = value
     
+    def resetClass(self):
+        self._transient_dict = {}
+        
+        
     def setupDefaults(self):
-   
+        pass
+        
     def finalizeData(self):
         raise NotImplementedError
         

--- a/AFL/automation/APIServer/data/DataTiled.py
+++ b/AFL/automation/APIServer/data/DataTiled.py
@@ -36,7 +36,7 @@ class DataTiled(DataPacket):
                 main_data = self._dict()['main_dataframe']
                 fxn = self.tiled_client.write_dataframe
             else:
-                main_data = [self._dict()['meta']['return_val']]
+                main_data = [np.nan]
                 fxn = self.tiled_client.write_array
             #self._print_dict_member_types(self._dict())
             self._sanitize()

--- a/AFL/automation/APIServer/data/DataTiled.py
+++ b/AFL/automation/APIServer/data/DataTiled.py
@@ -2,7 +2,8 @@ from .DataPacket import DataPacket
 import datetime
 import json
 import os
-import tiled
+import tiled.client
+import numpy as np
 
 class DataTiled(DataPacket):
     '''
@@ -14,7 +15,10 @@ class DataTiled(DataPacket):
         self.backup_path = backup_path
         self.tiled_client = tiled.client.from_uri(server,api_key=api_key)
         super().__init__()
-    def transmitData(self):
+    def finalize(self):
+        self.transmit()
+        self.reset()
+    def transmit(self):
         '''
             Transmits the data inside this container to Tiled.
 
@@ -22,14 +26,26 @@ class DataTiled(DataPacket):
             named according to the current time.
 
         '''
+
+        
         try:
-            if 'main_array' in data.keys():
-                self.tiled_client.write_array(data['main_array'],metadata=self._dict())
-            elif 'main_dataframe' in data.keys():
-                self.tiled_client.write_dataframe(data['main_dataframe'],metadata=self._dict())
+            if 'main_array' in self._dict().keys():
+                main_data = self._dict()['main_array']
+                fxn = self.tiled_client.write_array
+            elif 'main_dataframe' in self._dict().keys():
+                main_data = self._dict()['main_dataframe']
+                fxn = self.tiled_client.write_dataframe
             else:
-                self.tiled_client.write_array([np.nan],metadata=self._dict())
-        except Exception:
+                main_data = [self._dict()['meta']['return_val']]
+                fxn = self.tiled_client.write_array
+            #self._print_dict_member_types(self._dict())
+            self._sanitize()
+            #print(self._dict())
+            #self._print_dict_member_types(self._dict())
+            fxn(main_data,metadata =self._dict())
+        except Exception as e:
+            print(f'Exception while transmitting to Tiled! {e}. Saving data in backup store.')
+            self._sanitize()
             filename = str(datetime.datetime.now()).replace(' ','-')
             with open(f'{self.backup_path}/{filename}.json','w') as f:
                 json.dump(self._dict(),f)

--- a/AFL/automation/APIServer/data/DataTiled.py
+++ b/AFL/automation/APIServer/data/DataTiled.py
@@ -1,0 +1,36 @@
+from .DataPacket import DataPacket
+import datetime
+import json
+import os
+import tiled
+
+class DataTiled(DataPacket):
+    '''
+      A DataPacket implementation that serializes its data to Tiled
+      with backup to JSON, named according to the current time.
+    '''
+
+    def __init__(self,server,api_key,backup_path):
+        self.backup_path = backup_path
+        self.tiled_client = tiled.client.from_uri(server,api_key=api_key)
+        super().__init__()
+    def transmitData(self):
+        '''
+            Transmits the data inside this container to Tiled.
+
+            If a tiled connection fails or is not possible, serializes to JSON,
+            named according to the current time.
+
+        '''
+        try:
+            if 'main_array' in data.keys():
+                self.tiled_client.write_array(data['main_array'],metadata=self._dict())
+            elif 'main_dataframe' in data.keys():
+                self.tiled_client.write_dataframe(data['main_dataframe'],metadata=self._dict())
+            else:
+                self.tiled_client.write_array([np.nan],metadata=self._dict())
+        except Exception:
+            filename = str(datetime.datetime.now()).replace(' ','-')
+            with open(f'{self.backup_path}/{filename}.json','w') as f:
+                json.dump(self._dict(),f)
+

--- a/AFL/automation/APIServer/data/DataTrashcan.py
+++ b/AFL/automation/APIServer/data/DataTrashcan.py
@@ -1,0 +1,6 @@
+class DataTrashcan(DataPacket):
+'''
+  A DataPacket implementation *for testing only* that takes all its data and simply throws it away.
+'''
+    def transmitData(self):
+        pass

--- a/AFL/automation/APIServer/data/DataTrashcan.py
+++ b/AFL/automation/APIServer/data/DataTrashcan.py
@@ -1,6 +1,8 @@
+from .DataPacket import DataPacket
+
 class DataTrashcan(DataPacket):
-'''
-  A DataPacket implementation *for testing only* that takes all its data and simply throws it away.
-'''
+    '''
+      A DataPacket implementation *for testing only* that takes all its data and simply throws it away.
+    '''
     def transmitData(self):
         pass

--- a/AFL/automation/APIServer/data/DataTrashcan.py
+++ b/AFL/automation/APIServer/data/DataTrashcan.py
@@ -4,5 +4,5 @@ class DataTrashcan(DataPacket):
     '''
       A DataPacket implementation *for testing only* that takes all its data and simply throws it away.
     '''
-    def transmitData(self):
+    def transmit(self):
         pass

--- a/AFL/automation/instrument/SeabreezeUVVis.py
+++ b/AFL/automation/instrument/SeabreezeUVVis.py
@@ -87,6 +87,10 @@ class SeabreezeUVVis(Driver):
                     correct_nonlinearity=self.config['correctNonlinearity'])])
             time.sleep(self.config['exposure_delay'])
 
+        if self.data is not None:
+            self.data['mode'] = 'continuous'
+            self.data['spectrum'] = data
+        else:
         self._writedata(data)
 
         if not ret:
@@ -103,6 +107,10 @@ class SeabreezeUVVis(Driver):
         if self.config['saveSingleScan']:
             self._writedata(data)
 
+        if self.data is not None:
+            self.data['mode'] = 'single'
+            self.data['spectrum'] = data
+            
         return data
 
     def _writedata(self,data):

--- a/AFL/automation/loading/LabJackSensor.py
+++ b/AFL/automation/loading/LabJackSensor.py
@@ -3,6 +3,8 @@ from labjack import ljm
 from AFL.automation.loading.Sensor import Sensor
 import time
 
+
+
 class LabJackSensor(Sensor):
     def __init__(self,devicetype="ANY",connection="ANY",deviceident="ANY",port_to_read="AIN0",polling_rate=200,intermittent_device_handle=False):
         '''
@@ -15,6 +17,7 @@ class LabJackSensor(Sensor):
     	deviceident (str): serial number OR IP OR device name OR "ANY"
     	port_to_read (str): LabJack port for device
         '''
+        self.fio = "DIO5"
         self.device_handle = ljm.openS(devicetype, connection, deviceident)
         self.port_to_read = port_to_read
         self.devicetype = devicetype
@@ -23,7 +26,7 @@ class LabJackSensor(Sensor):
         self.intervalHandle = 0
         self.intermittent_device_handle = intermittent_device_handle
         ljm.startInterval(self.intervalHandle, polling_rate)
-        ljm.eWriteName(self.device_handle,"DIO6",1)#set physical FIO6 / logical DIO6 to TTL-hi
+        ljm.eWriteName(self.device_handle,self.fio,1)#set physical FIO6 / logical DIO6 to TTL-hi
         if self.intermittent_device_handle:
             ljm.close(self.device_handle)
 
@@ -31,9 +34,9 @@ class LabJackSensor(Sensor):
     	ljm.close(self.device_handle)
     	
     def calibrate(self):
-        ljm.eWriteName(self.device_handle,"DIO6",0)
+        ljm.eWriteName(self.device_handle,self.fio,0)
         time.sleep(0.2)
-        ljm.eWriteName(self.device_handle,"DIO6",1)
+        ljm.eWriteName(self.device_handle,self.fio,1)
         if self.intermittent_device_handle:
             ljm.close(self.device_handle)
         

--- a/AFL/automation/loading/LoadStopperDriver.py
+++ b/AFL/automation/loading/LoadStopperDriver.py
@@ -31,6 +31,7 @@ class LoadStopperDriver(Driver):
 
     def __init__(self,sensor,load_client=None,load_object=None,auto_initialize=True,overrides=None,data=None):
         self._app = None
+        self.data = data
         Driver.__init__(self,name='LoadStopperDriver',defaults=self.gather_defaults(),overrides=overrides,data=data)
 
         self.load_object = load_object

--- a/AFL/automation/loading/LoadStopperDriver.py
+++ b/AFL/automation/loading/LoadStopperDriver.py
@@ -29,10 +29,9 @@ class LoadStopperDriver(Driver):
     defaults['stopper_baseline_duration'] = 10
     defaults['stopper_filepath'] = str(pathlib.Path.home()/'.afl/loadstopper_data/')
 
-    def __init__(self,sensor,load_client=None,load_object=None,auto_initialize=True,overrides=None,data=None):
+    def __init__(self,sensor,load_client=None,load_object=None,auto_initialize=True,overrides=None):
         self._app = None
-        self.data = data
-        Driver.__init__(self,name='LoadStopperDriver',defaults=self.gather_defaults(),overrides=overrides,data=data)
+        Driver.__init__(self,name='LoadStopperDriver',defaults=self.gather_defaults(),overrides=overrides)
 
         self.load_object = load_object
         self.load_client = load_client

--- a/AFL/automation/loading/LoadStopperDriver.py
+++ b/AFL/automation/loading/LoadStopperDriver.py
@@ -29,10 +29,11 @@ class LoadStopperDriver(Driver):
     defaults['stopper_baseline_duration'] = 10
     defaults['stopper_filepath'] = str(pathlib.Path.home()/'.afl/loadstopper_data/')
 
-    def __init__(self,sensor,load_client=None,load_object=None,auto_initialize=True,overrides=None):
+    def __init__(self,sensor,load_client=None,load_object=None,auto_initialize=True,overrides=None,data=None)
         self._app = None
         Driver.__init__(self,name='LoadStopperDriver',defaults=self.gather_defaults(),overrides=overrides)
-
+        if self.data is not None:
+            self.data = data
         self.load_object = load_object
         self.load_client = load_client
 
@@ -98,7 +99,7 @@ class LoadStopperDriver(Driver):
     def reset_poll(self):
         if self.poll is not None:
             self.poll.terminate()
-        self.poll = SensorPollingThread(self.sensor,period=self.config['period'],window=self.config['poll_window'],daemon=True)
+        self.poll = SensorPollingThread(self.sensor,period=self.config['period'],window=self.config['poll_window'],daemon=True,data=self.data)
 
     def reset_stopper(self):
         if self.stopper is not None:
@@ -137,7 +138,8 @@ class LoadStopperDriver(Driver):
             baseline_duration = self.config['stopper_baseline_duration'],
             filepath=self.config['stopper_filepath'],
             daemon=True,
-    )
+            data = self.data
+        )
 
         
         

--- a/AFL/automation/loading/PneumaticSampleCell.py
+++ b/AFL/automation/loading/PneumaticSampleCell.py
@@ -43,7 +43,6 @@ class PneumaticSampleCell(Driver,SampleCell):
                       waste_tank_level=0,
                       load_stopper=None,
                       overrides=None, 
-                      data=None,
                       ):
         '''
             pump: a pump object supporting withdraw() and dispense() methods
@@ -56,7 +55,7 @@ class PneumaticSampleCell(Driver,SampleCell):
 
         '''
         self._app = None
-        Driver.__init__(self,name='PneumaticSampleCell',defaults=self.gather_defaults(),overrides=overrides,data=data)
+        Driver.__init__(self,name='PneumaticSampleCell',defaults=self.gather_defaults(),overrides=overrides)
         self.pump = pump
         self.relayboard = relayboard
         self.cell_state = defaultdict(lambda: 'clean')

--- a/AFL/automation/loading/SensorCallbackThread.py
+++ b/AFL/automation/loading/SensorCallbackThread.py
@@ -7,7 +7,7 @@ import pathlib
 
             
 class SensorCallbackThread(threading.Thread):
-    def __init__(self,poll,period=0.1,daemon=True,filepath=None):
+    def __init__(self,poll,period=0.1,daemon=True,filepath=None,data=None):
         threading.Thread.__init__(self, name='CallbackThread', daemon=daemon)
 
         self.app = None

--- a/AFL/automation/loading/SensorCallbackThread.py
+++ b/AFL/automation/loading/SensorCallbackThread.py
@@ -7,11 +7,11 @@ import pathlib
 
             
 class SensorCallbackThread(threading.Thread):
-    def __init__(self,poll,period=0.1,daemon=True,filepath=None,data=None):
+    def __init__(self,poll,period=0.1,daemon=True,filepath=None):
         threading.Thread.__init__(self, name='CallbackThread', daemon=daemon)
 
         self.app = None
-        self.data = data
+        self.data = None
 
         self.poll = poll
         self.period = period

--- a/AFL/automation/loading/SensorCallbackThread.py
+++ b/AFL/automation/loading/SensorCallbackThread.py
@@ -65,9 +65,8 @@ class StopLoadCBv1(SensorCallbackThread):
         baseline_duration = 2,
         daemon=True,
         filepath=None,
-        data=None,
     ):
-        super().__init__(poll=poll,period=period,daemon=daemon,filepath=filepath,data=data)
+        super().__init__(poll=poll,period=period,daemon=daemon,filepath=filepath)
         self.load_client = load_client
         self.threshold_npts = threshold_npts
         self.threshold_v_step = threshold_v_step 
@@ -144,9 +143,8 @@ class StopLoadCBv2(SensorCallbackThread):
         instatrigger = True,
         daemon=True,
         filepath=None,
-        data=None,
     ):
-        super().__init__(poll=poll,period=period,daemon=daemon,filepath=filepath,data=data)
+        super().__init__(poll=poll,period=period,daemon=daemon,filepath=filepath)
         self.loader_comm = LoaderCommunication(load_client=load_client,load_object=load_object)
         self.threshold_npts = threshold_npts
         self.threshold_v_step = threshold_v_step 

--- a/AFL/automation/loading/SensorPollingThread.py
+++ b/AFL/automation/loading/SensorPollingThread.py
@@ -4,9 +4,12 @@ import time
 import datetime
 
 class SensorPollingThread(threading.Thread):
-    def __init__(self,sensor,period=0.1,callback=None,hv_pipe=None,window=None,filename=None,daemon=True):
+    def __init__(self,sensor,period=0.1,callback=None,hv_pipe=None,window=None,filename=None,daemon=True,data=None):
         threading.Thread.__init__(self, name='SignalPollingThread', daemon=daemon)
         
+        self.app = None
+        self.data = None
+
         self.sensor = sensor
         self.callback = callback
         self.window = window

--- a/AFL/automation/prepare/OT2_Driver.py
+++ b/AFL/automation/prepare/OT2_Driver.py
@@ -346,6 +346,9 @@ class OT2_Driver(Driver):
         user_mix_before = mix_before
         user_mix_after = mix_after
 
+        if self.data is not None:
+            self.data['transfer_strategy'] = transfers
+
         for i,sub_volume in enumerate(transfers):
             #get pipette based on volume
             pipette = self.get_pipette(sub_volume)
@@ -421,7 +424,7 @@ class OT2_Driver(Driver):
                     transfer = self.min_transfer
                 if (transfer<self.min_largest_pipette) and (transfer>self.max_smallest_pipette): # Valley of death
                     #n_transfers = np.ceil(transfer/self.max_smallest_pipette)
-                    transfer = self.max_smallest_pipette #I fear no evil
+                    transfer = self.max_smallest_pipette # I fear no evil
                 
                 transfers.append(transfer)
             else:
@@ -588,6 +591,10 @@ class OT2_Driver(Driver):
         if not pipettes:
             raise ValueError('No suitable pipettes found!\n')
         
+        if self.data is not None:
+            self.data['transfer_method'] = method
+            self.data['pipette_options'] = pipettes
+
         if(method == 'uncertainty'):
             pipette = min(pipettes,key=lambda x: x['uncertainty'])
         elif(method == 'min_transfers'):
@@ -597,10 +604,12 @@ class OT2_Driver(Driver):
         else:
             raise ValueError(f'Pipette selection method {method} was not recognized.')
         self.app.logger.debug(f'Chosen pipette: {pipette}')
+        if self.data is not None:
+            self.data['chosen_pipette'] = pipette
         return pipette['object']
 
     def _pipette_uncertainty(self,maxvolume,volume,errortype):
-        '''pipet uncertainties from the opentrons gen 1 whitepaper 
+        '''pipette uncertainties from the opentrons gen 1 whitepaper 
         @ https://opentrons.com/publications/OT-2-Pipette-White-Paper-GEN1.pdf
         
         pipette          moving uL      random error uL ±     systematic error uL ±

--- a/AFL/automation/prepare/SampleSeries.py
+++ b/AFL/automation/prepare/SampleSeries.py
@@ -46,7 +46,7 @@ class SampleSeries:
             for stock,(loc,mass) in sample.balancer.mass_transfers.items():
                 mass_totals[loc] += mass
         return mass_totals
-
+    
     def mass_totals_component(self,only_validated=True):
         mass_totals = defaultdict(float)
         solution = Solution('dummy',[])

--- a/AFL/automation/sample/SAS_LoaderV2_SampleDriver.py
+++ b/AFL/automation/sample/SAS_LoaderV2_SampleDriver.py
@@ -22,11 +22,10 @@ class SAS_LoaderV2_SampleDriver(Driver):
             camera_urls = None,
             snapshot_directory =None,
             overrides=None, 
-            data=None,
 
             ):
 
-        Driver.__init__(self,name='SAS_SampleDriver',defaults=self.gather_defaults(),overrides=overrides,data=data)
+        Driver.__init__(self,name='SAS_SampleDriver',defaults=self.gather_defaults(),overrides=overrides)
 
         if not (len(load_url.split(':'))==2):
             raise ArgumentError('Need to specify both ip and port on load_url')

--- a/AFL/automation/shared/PersistentConfig.py
+++ b/AFL/automation/shared/PersistentConfig.py
@@ -3,8 +3,9 @@ import datetime
 import pathlib
 import copy
 import warnings
+from collections.abc import MutableMapping
 
-class PersistentConfig:
+class PersistentConfig(MutableMapping):
     ''' A dictionary-like class that serializes changes to disk
     
     This class provides dictionary-like setters and getters (e.g., [] and 
@@ -124,7 +125,12 @@ class PersistentConfig:
     def __iter__(self):
         for key,value in self.config.items():
             yield key,value
-    
+    def __len__(self):
+        return len(self.config)
+    def __delitem__(self,key):
+        del self.config[key]
+        self._update_history()
+        
     def update(self,update_dict): 
         '''Update several values in config at once
         

--- a/AFL/automation/shared/PersistentConfig.py
+++ b/AFL/automation/shared/PersistentConfig.py
@@ -115,6 +115,12 @@ class PersistentConfig:
         self.config[key] = value
         self._update_history()
 
+    def toJSON(self):
+        '''
+        Serialize the config to json
+        '''
+        return json.dumps(self.config)
+        
     def __iter__(self):
         for key,value in self.config.items():
             yield key,value

--- a/server_scripts/Dummy.py
+++ b/server_scripts/Dummy.py
@@ -7,10 +7,11 @@ except:
         print(f'Could not find NistoRoboto on system path, adding {os.path.abspath(Path(__file__).parent.parent)} to PYTHONPATH')
 
 from AFL.automation.APIServer.APIServer import APIServer
-from AFL.automation.APIServer.driver.DummyDriver import DummyDriver
-from AFL.automation.APIServer.driver.NICE_SampleDriver import NICE_SampleDriver
+from AFL.automation.APIServer.DummyDriver import DummyDriver
+from AFL.automation.APIServer.data.DataTiled import DataTiled
 
-server = APIServer('DummyPumpServer',index_template="index_pump.html")
+data = DataTiled('http://afl-inst-lab:8000',api_key = os.environ['TILED_API_KEY'],backup_path='/Users/pab2/.afl/json-backup')
+server = APIServer('DummyPumpServer',index_template="index_pump.html",data = data)
 server.add_standard_routes()
 server.create_queue(DummyDriver(name='DummyPump'))
 server.init_logging()

--- a/server_scripts/LoaderV2Pneumatic_CDSAXS.py
+++ b/server_scripts/LoaderV2Pneumatic_CDSAXS.py
@@ -26,7 +26,7 @@ from AFL.automation.loading.LabJackSensor import LabJackSensor
 from AFL.automation.loading.LoadStopperDriver import LoadStopperDriver
 from AFL.automation.APIServer.data.DataTiled import DataTiled
 
-data = DataTiled('http://afl-inst-lab.campus.nist.gov:8000',api_key = os.environ['TILED_API_KEY'],backup_path='/Users/pab2/.afl/json-backup')
+data = DataTiled('http://afl-inst-lab.campus.nist.gov:8000',api_key = os.environ['TILED_API_KEY'],backup_path='/home/pi/.afl/json-backup')
 
 
 #load stopper stuff
@@ -45,8 +45,8 @@ relayboard = PiPlatesRelay(
 
 #digout = LabJackDigitalOut(intermittent_device_handle=False,port_to_write='TDAC4',shared_device = sensor)
 #p_ctrl = DigitalOutPressureController(digout,3)
-p_ctrl = UltimusVPressureController('/dev/ttyUSB0', data = data)
-pump = PressureControllerAsPump(p_ctrl,dispense_pressure = 4, implied_flow_rate = 5, data = data)
+p_ctrl = UltimusVPressureController('/dev/ttyUSB0')
+pump = PressureControllerAsPump(p_ctrl,dispense_pressure = 4, implied_flow_rate = 5)
 #DummyPump() # ID for 10mL = 14.859, for 50 mL 26.43
 # pump = NE1kSyringePump('/dev/ttyUSB0',14.86,10,baud=19200,pumpid=10,flow_delay=0) # ID for 10mL = 14.859, for 50 mL 26.43
 # this is the line used in AFL ops   pump = NE1kSyringePump('/dev/ttyUSB0',14.6,10,baud=19200,pumpid=10,flow_delay=0) # ID for 10mL = 14.859, for 50 mL 26.43 (gastight)
@@ -55,11 +55,11 @@ pump = PressureControllerAsPump(p_ctrl,dispense_pressure = 4, implied_flow_rate 
 #gpio = PiGPIO({23:'ARM_UP',24:'ARM_DOWN'},pull_dir='DOWN')
 #16,19 also shot
 
-gpio = PiGPIO({4:'DOOR',14:'ARM_UP',15:'ARM_DOWN'},pull_dir='UP', data = data) #: p21-blue, p20-purple: 1, p26-grey: 1}
+gpio = PiGPIO({4:'DOOR',14:'ARM_UP',15:'ARM_DOWN'},pull_dir='UP') #: p21-blue, p20-purple: 1, p26-grey: 1}
 
 
 driver = PneumaticSampleCell(pump,relayboard,digitalin=gpio,load_stopper=load_stopper, data = data)
-server = APIServer('CellServer')
+server = APIServer('CellServer',data=data)
 server.add_standard_routes()
 server.create_queue(driver)
 server.init_logging(toaddrs=['tbm@nist.gov'])

--- a/server_scripts/LoaderV2Pneumatic_CDSAXS.py
+++ b/server_scripts/LoaderV2Pneumatic_CDSAXS.py
@@ -1,0 +1,70 @@
+import os,sys,subprocess
+from pathlib import Path
+
+try:
+        import AFL.automation
+except:
+        sys.path.append(os.path.abspath(Path(__file__).parent.parent))
+        print(f'Could not find AFL.automation on system path, adding {os.path.abspath(Path(__file__).parent.parent)} to PYTHONPATH')
+
+server_port=5000
+
+from AFL.automation.APIServer.APIServer import APIServer
+
+from AFL.automation.loading.PneumaticSampleCell import PneumaticSampleCell
+from AFL.automation.loading.DummyPump import DummyPump
+from AFL.automation.loading.NE1kSyringePump import NE1kSyringePump
+from AFL.automation.loading.PiPlatesRelay import PiPlatesRelay
+from AFL.automation.loading.SainSmartRelay import SainSmartRelay
+from AFL.automation.loading.PiGPIO import PiGPIO
+from AFL.automation.loading.Tubing import Tubing
+from AFL.automation.loading.PressureControllerAsPump import PressureControllerAsPump
+from AFL.automation.loading.UltimusVPressureController import UltimusVPressureController
+#from AFL.automation.loading.DigitalOutPressureController import DigitalOutPressureController
+#from AFL.automation.loading.LabJackDigitalOut import LabJackDigitalOut
+from AFL.automation.loading.LabJackSensor import LabJackSensor
+from AFL.automation.loading.LoadStopperDriver import LoadStopperDriver
+
+
+#load stopper stuff
+sensor = LabJackSensor()
+load_stopper = LoadStopperDriver(sensor,auto_initialize=False)
+
+relayboard = PiPlatesRelay(
+        {
+        6:'arm-up',7:'arm-down',
+        5:'rinse1',4:'rinse2',3:'blow',2:'piston-vent',1:'postsample'
+
+        } )
+
+#digout = LabJackDigitalOut(intermittent_device_handle=False,port_to_write='TDAC4',shared_device = sensor)
+#p_ctrl = DigitalOutPressureController(digout,3)
+p_ctrl = UltimusVPressureController('/dev/ttyUSB0')
+pump = PressureControllerAsPump(p_ctrl,dispense_pressure = 5, implied_flow_rate = 5)
+#DummyPump() # ID for 10mL = 14.859, for 50 mL 26.43
+# pump = NE1kSyringePump('/dev/ttyUSB0',14.86,10,baud=19200,pumpid=10,flow_delay=0) # ID for 10mL = 14.859, for 50 mL 26.43
+# this is the line used in AFL ops   pump = NE1kSyringePump('/dev/ttyUSB0',14.6,10,baud=19200,pumpid=10,flow_delay=0) # ID for 10mL = 14.859, for 50 mL 26.43 (gastight)
+# pump = NE1kSyringePump('/dev/ttyUSB0',14.0,10,baud=19200,pumpid=10,flow_delay=0) # ID for 10mL = 14.859, for 50 mL 26.43
+# pump = NE1kSyringePump('/dev/ttyUSB0',11.4,5,baud=19200,pumpid=10,flow_delay=0) # ID for 10mL = 14.859, for 50 mL 26.43
+#gpio = PiGPIO({23:'ARM_UP',24:'ARM_DOWN'},pull_dir='DOWN')
+#16,19 also shot
+
+gpio = PiGPIO({4:'DOOR',14:'ARM_UP',15:'ARM_DOWN'},pull_dir='UP') #: p21-blue, p20-purple: 1, p26-grey: 1}
+
+
+driver = PneumaticSampleCell(pump,relayboard,digitalin=gpio,load_stopper=load_stopper)
+server = APIServer('CellServer')
+server.add_standard_routes()
+server.create_queue(driver)
+server.init_logging(toaddrs=['tbm@nist.gov'])
+server.run(host='0.0.0.0',port=server_port, debug=False)
+
+
+# process = subprocess.Popen(['/bin/bash','-c',f'chromium-browser --start-fullscreen http://localhost:{server_port}'])#, shell=True, stdout=subprocess.PIPE)
+# 
+# server.run_threaded(host='0.0.0.0', port=server_port, debug=False)
+# 
+# process.wait()
+# 
+# server._stop()
+# server.join()

--- a/server_scripts/LoaderV2Pneumatic_CDSAXS.py
+++ b/server_scripts/LoaderV2Pneumatic_CDSAXS.py
@@ -58,7 +58,8 @@ pump = PressureControllerAsPump(p_ctrl,dispense_pressure = 4, implied_flow_rate 
 gpio = PiGPIO({4:'DOOR',14:'ARM_UP',15:'ARM_DOWN'},pull_dir='UP') #: p21-blue, p20-purple: 1, p26-grey: 1}
 
 
-driver = PneumaticSampleCell(pump,relayboard,digitalin=gpio,load_stopper=load_stopper, data = data)
+
+driver = PneumaticSampleCell(pump,relayboard,digitalin=gpio,load_stopper=load_stopper)
 server = APIServer('CellServer',data=data)
 server.add_standard_routes()
 server.create_queue(driver)

--- a/server_scripts/LoaderV2Pneumatic_CDSAXS.py
+++ b/server_scripts/LoaderV2Pneumatic_CDSAXS.py
@@ -58,7 +58,6 @@ pump = PressureControllerAsPump(p_ctrl,dispense_pressure = 4, implied_flow_rate 
 gpio = PiGPIO({4:'DOOR',14:'ARM_UP',15:'ARM_DOWN'},pull_dir='UP') #: p21-blue, p20-purple: 1, p26-grey: 1}
 
 
-load_stopper.data = data
 driver = PneumaticSampleCell(pump,relayboard,digitalin=gpio,load_stopper=load_stopper)
 server = APIServer('CellServer',data=data)
 server.add_standard_routes()

--- a/server_scripts/LoaderV2Pneumatic_CDSAXS.py
+++ b/server_scripts/LoaderV2Pneumatic_CDSAXS.py
@@ -31,7 +31,7 @@ data = DataTiled('http://afl-inst-lab.campus.nist.gov:8000',api_key = os.environ
 
 #load stopper stuff
 sensor = LabJackSensor()
-load_stopper = LoadStopperDriver(sensor, data = data,auto_initialize=False)
+load_stopper = LoadStopperDriver(sensor,auto_initialize=False)
 #load_stopper = None
 #sensor = None
 

--- a/server_scripts/LoaderV2Pneumatic_CDSAXS.py
+++ b/server_scripts/LoaderV2Pneumatic_CDSAXS.py
@@ -58,7 +58,7 @@ pump = PressureControllerAsPump(p_ctrl,dispense_pressure = 4, implied_flow_rate 
 gpio = PiGPIO({4:'DOOR',14:'ARM_UP',15:'ARM_DOWN'},pull_dir='UP') #: p21-blue, p20-purple: 1, p26-grey: 1}
 
 
-
+load_stopper.data = data
 driver = PneumaticSampleCell(pump,relayboard,digitalin=gpio,load_stopper=load_stopper)
 server = APIServer('CellServer',data=data)
 server.add_standard_routes()

--- a/server_scripts/LoaderV2Pneumatic_CDSAXS.sh
+++ b/server_scripts/LoaderV2Pneumatic_CDSAXS.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -i
+
+git config --global credential.helper store
+
+source activate nistoroboto
+
+cd ~/NistoRoboto/
+git pull
+
+python ~/NistoRoboto/server_scripts/LoaderV2Pneumatic.py

--- a/server_scripts/LoaderV2Pneumatic_CDSAXS.sh
+++ b/server_scripts/LoaderV2Pneumatic_CDSAXS.sh
@@ -4,6 +4,19 @@ git config --global credential.helper store
 
 #source activate nistoroboto
 
+
+if [[ -z "${TILED_API_KEY}" ]]; then
+  export TILED_API_KEY=$(cat ~/.afl/tiled_api_key)
+else
+  export TILED_API_KEY="${TILED_API_KEY}"
+fi
+
+if [[ -z "${AFL_SYSTEM_SERIAL}" ]]; then
+  export AFL_SYSTEM_SERIAL=$(cat ~/.afl/system_serial)
+else
+  export AFL_SYSTEM_SERIAL="${AFL_SYSTEM_SERIAL}"
+fi
+
 cd ~/NistoRoboto/
 git pull
 

--- a/server_scripts/LoaderV2Pneumatic_CDSAXS.sh
+++ b/server_scripts/LoaderV2Pneumatic_CDSAXS.sh
@@ -2,7 +2,7 @@
 
 git config --global credential.helper store
 
-source activate nistoroboto
+#source activate nistoroboto
 
 cd ~/NistoRoboto/
 git pull

--- a/server_scripts/OT2.py
+++ b/server_scripts/OT2.py
@@ -1,7 +1,11 @@
 from AFL.automation.APIServer.APIServer import APIServer
 from AFL.automation.prepare.OT2_Driver import OT2_Driver
+from AFL.automation.APIServer.data.DataTiled import DataTiled
+
+
 import os
-server = APIServer('OT2Server')
+data = DataTiled('http://afl-inst-lab.campus.nist.gov:8000',api_key = os.environ['TILED_API_KEY'],backup_path='/Users/pab2/.afl/json-backup')
+server = APIServer('OT2Server',data = data)
 driver = OT2_Driver()
 server.add_standard_routes()
 server.create_queue(driver)

--- a/server_scripts/OT2.sh
+++ b/server_scripts/OT2.sh
@@ -11,6 +11,12 @@ else
 	export PYTHONPATH=/var/user-packages/root/.local/lib/python3.7/site-packages
 fi
 
+if [[ -z "${TILED_API_KEY}" ]]; then
+  export TILED_API_KEY=$(cat ~/.afl/tiled_api_key)
+else
+  export TILED_API_KEY="${TILED_API_KEY}"
+fi
+
 # add NistoRoboto to PYTHONPATH
 # export PYTHONPATH=/root/user_storage/:${PYTHONPATH}
 export PYTHONPATH=/root/user_storage/NistoRoboto:${PYTHONPATH}

--- a/server_scripts/OT2.sh
+++ b/server_scripts/OT2.sh
@@ -17,6 +17,12 @@ else
   export TILED_API_KEY="${TILED_API_KEY}"
 fi
 
+if [[ -z "${AFL_SYSTEM_SERIAL}" ]]; then
+  export AFL_SYSTEM_SERIAL=$(cat ~/.afl/system_serial)
+else
+  export AFL_SYSTEM_SERIAL="${AFL_SYSTEM_SERIAL}"
+fi
+
 # add NistoRoboto to PYTHONPATH
 # export PYTHONPATH=/root/user_storage/:${PYTHONPATH}
 export PYTHONPATH=/root/user_storage/NistoRoboto:${PYTHONPATH}

--- a/server_scripts/Seabreeze.py
+++ b/server_scripts/Seabreeze.py
@@ -8,13 +8,13 @@ except:
 
 from AFL.automation.APIServer.APIServer import APIServer
 from AFL.automation.instrument.SeabreezeUVVis import SeabreezeUVVis
-from AFL.automation.APIServer.Data.DataTiled import DataTiled
+from AFL.automation.APIServer.data.DataTiled import DataTiled
 
 data = DataTiled('http://afl-inst-lab.campus.nist.gov:8000',api_key = os.environ['TILED_API_KEY'],backup_path='/home/pi/.afl/json-backup')
 
 server_port=5050
 
-driver = SeabreezeUVVis()
+driver = SeabreezeUVVis(backend='pyseabreeze')
 server = APIServer('Ocean Optics',contact='pab2@nist.gov',data=data)
 server.add_standard_routes()
 

--- a/server_scripts/Seabreeze.py
+++ b/server_scripts/Seabreeze.py
@@ -8,11 +8,14 @@ except:
 
 from AFL.automation.APIServer.APIServer import APIServer
 from AFL.automation.instrument.SeabreezeUVVis import SeabreezeUVVis
+from AFL.automation.APIServer.Data.DataTiled import DataTiled
+
+data = DataTiled('http://afl-inst-lab.campus.nist.gov:8000',api_key = os.environ['TILED_API_KEY'],backup_path='/home/pi/.afl/json-backup')
 
 server_port=5050
 
 driver = SeabreezeUVVis()
-server = APIServer('Ocean Optics',contact='pab2@nist.gov')
+server = APIServer('Ocean Optics',contact='pab2@nist.gov',data=data)
 server.add_standard_routes()
 
 server.create_queue(driver)


### PR DESCRIPTION
I believe this is now ready to merge.

The gist:

 - adds a `data` object to the core of Driver, which is an instance of a subclass of `AFL.automation.APIServer.data.DataPacket` and behaves like a dict with several stunt features.
 - adds 3 implementations of `DataPacket`: `DataTrashcan` (which discards data), `DataJSON`, and `DataTiled` which serialize to JSON and a writable `Tiled` server, respectively.
 - adds several hooks for data writing to APIServer and QueueDaemon to cause QueueDaemon to write a datapacket and reset the data class after each queued task.
 - misc along-the-way improvements, such as changing `PersistentConfig` to inherit from `abc.MutableMapping`