### PR TITLE
Touch Tip functionality

### DIFF
--- a/AFL/automation/prepare/OT2_Driver.py
+++ b/AFL/automation/prepare/OT2_Driver.py
@@ -281,6 +281,7 @@ class OT2_Driver(Driver):
             to_center=False,
             to_top_z_offset=0,
             fast_mixing=False,
+            touch_tip=False,
             **kwargs):
         '''Transfer fluid from one location to another
 
@@ -406,7 +407,8 @@ class OT2_Driver(Driver):
                     drop_tip=drop_tip,
                     force_new_tip=force_new_tip,
                     mix_aspirate_rate=mix_aspirate_rate,
-                    mix_dispense_rate=mix_dispense_rate)
+                    mix_dispense_rate=mix_dispense_rate,
+                    touch_tip=touch_tip)
 
             self.last_pipette = pipette
 
@@ -444,8 +446,15 @@ class OT2_Driver(Driver):
             drop_tip=True,
             force_new_tip=False,
             mix_aspirate_rate=None,
-            mix_dispense_rate=None):
-                      
+            mix_dispense_rate=None,
+            touch_tip=False):
+
+        #does a touch tip call at the current location but at -2 mm below the top of the location
+        if touch_tip and self.has_tip:
+            if source_well:
+                pipette.touch_tip(location=source_well.top(),v_offset=-2)
+            elif dest_well:
+                pipette.touch_tip(location=dest_well.top(),v_offset=-2)
     
         if force_new_tip and self.has_tip:
             pipette.drop_tip(self.protocol.deck[12]['A1'])


### PR DESCRIPTION
added the boolean flag touch_tip to the transfer function in the OT2_Driver.py script. THIS NEEDS TO BE TESTED ON HARDWARE STILL

If there is a tip on the pipette and the flag is set to True, the robot should tap the tip 2 mm below the top of the well plate after drawing fluid and after dispensing fluid.

There are other parameters in the pipette action but the boolean might be enough for now. see documentation [https://docs.opentrons.com/v2/new_atomic_commands.html](url)