### PR TITLE
Add concurrency limit to Docs4NIST

### DIFF
--- a/.github/workflows/Docs4NIST.yml
+++ b/.github/workflows/Docs4NIST.yml
@@ -2,6 +2,10 @@ name: "Build Documentation"
 
 on: [push, pull_request, delete]
 
+concurrency:
+   group: ${{ github.workflow }}
+   cancel-in-progress: false
+   
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Docs4NIST does not handle multiple concurrent runs well; a race condition causes workflow failures.  This small patch limits Docs4NIST runs to one-at-a-time to avoid this.