### PR TITLE
bugfix: stop resetting quickbar items on page update

### DIFF
--- a/AFL/automation/APIServer/templates/index-new.html
+++ b/AFL/automation/APIServer/templates/index-new.html
@@ -307,10 +307,6 @@
                 updateTaskList("#queued", result[2], "queued");
             });
 
-            // Retrieve queued commands
-            $.get("/get_queued_commands", function (data) {
-                displayCommands("#queued-commands", data);
-            });
         }
 
  // Function to display commands and handle command execution
@@ -380,13 +376,18 @@ function displayCommands(containerId, commands) {
     }
 }
 
-        // Populate quickbar controls once on page load
+        // Initial update
+
+        update();
+        // Retrieve unqueued commands
         $.get("/get_quickbar", function (data) {
             displayCommands("#quickbar-commands", data);
         });
 
-        // Initial update of status information
-        update();
+        // Retrieve queued commands
+        $.get("/get_queued_commands", function (data) {
+                displayCommands("#queued-commands", data);
+            });
         setInterval(update, 500); // Update every 0.5 seconds
         setTimeout(function () {
             $('#running')[0].scrollIntoView();


### PR DESCRIPTION
quickbar items in the "new" (since 2 years) status page were previously being refreshed every time the page refreshed, ~5 sec, making it hard to type in.  This fixes that refresh by fetching the quickbar once on page load.