### PR TITLE
OrchestratorDriver should read predict results from Tiled

### DIFF
--- a/AFL/automation/orchestrator/OrchestratorDriver.py
+++ b/AFL/automation/orchestrator/OrchestratorDriver.py
@@ -4,7 +4,7 @@ import pathlib
 import shutil
 import traceback
 import uuid
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Any, Tuple
 import warnings
 import os
 import time
@@ -82,6 +82,7 @@ class OrchestratorDriver(Driver):
     defaults['prepare_volume'] = '1000 ul'
     defaults['empty_prefix'] = 'MT-'
     defaults['composition_format'] = 'mass_fraction'
+    defaults['next_samples_variable'] = 'next_samples'
     def __init__(
             self,
             camera_urls: Optional[List[str]] = None,
@@ -407,11 +408,12 @@ class OrchestratorDriver(Driver):
 
         # Look away ... here be dragons ...
         if enqueue_next:
-            ag_result = self.get_client('agent').retrieve_obj(uid=self.uuid['agent'])
-            next_samples = ag_result['next_samples']
-            
-            # Convert next_samples to Solution-compatible format
-            new_sample = next_samples.to_pandas().squeeze().to_dict()
+            entry_id, entry = self._get_latest_predict_tiled_entry(sample_uuid=self.uuid['sample'])
+            new_sample = self._extract_next_sample_from_tiled_entry(
+                entry=entry,
+                variable_name=self.config['next_samples_variable'],
+                entry_id=entry_id,
+            )
             # Convert to concentrations format for Solution
             new_sample_dict = {
                 'concentrations': {k: f"{v} mg/ml" for k, v in new_sample.items()},
@@ -434,6 +436,126 @@ class OrchestratorDriver(Driver):
 
             queue_loc = self._queue.qsize() #append at end of queue
             self._queue.put(package,queue_loc)
+
+    @staticmethod
+    def _get_nested_metadata_value(metadata: Dict[str, Any], path: str) -> Any:
+        current: Any = metadata
+        for part in path.split('.'):
+            if not isinstance(current, dict):
+                return None
+            if part not in current:
+                return None
+            current = current[part]
+        return current
+
+    def _iter_predict_entries_for_sample(self, sample_uuid: str) -> List[Tuple[str, Any]]:
+        """Find predict-task tiled entries for a sample UUID using metadata key variants."""
+        sample_uuid_fields = ('sample_uuid', 'attrs.sample_uuid', 'attr.sample_uuid')
+        task_name_fields = ('task_name', 'attrs.task_name', 'attr.task_name')
+
+        candidate_entries: Dict[str, Any] = {}
+        query_errors = []
+
+        for sample_field in sample_uuid_fields:
+            for task_field in task_name_fields:
+                try:
+                    results = (
+                        self.tiled_client
+                        .search(Eq(sample_field, sample_uuid))
+                        .search(Eq(task_field, 'predict'))
+                    )
+                    for entry_id, entry in results.items():
+                        candidate_entries[entry_id] = entry
+                except Exception as exc:
+                    query_errors.append(str(exc))
+                    continue
+
+        if candidate_entries:
+            return list(candidate_entries.items())
+
+        error_msg = (
+            f"No predict entries found in Tiled for sample_uuid={sample_uuid} "
+            f"using keys {sample_uuid_fields} and task keys {task_name_fields}."
+        )
+        if query_errors:
+            error_msg = f"{error_msg} Query errors: {' | '.join(query_errors)}"
+        self.app.logger.error(error_msg)
+        raise ValueError(error_msg)
+
+    def _entry_sort_timestamp(self, entry: Any) -> datetime.datetime:
+        metadata = dict(getattr(entry, 'metadata', {}) or {})
+        timestamp_paths = (
+            'meta.ended',
+            'attrs.meta.ended',
+            'attr.meta.ended',
+            'meta.started',
+            'attrs.meta.started',
+            'attr.meta.started',
+            'timestamp',
+            'attrs.timestamp',
+            'attr.timestamp',
+        )
+        for path in timestamp_paths:
+            value = self._get_nested_metadata_value(metadata, path)
+            if isinstance(value, datetime.datetime):
+                return value
+            if isinstance(value, str):
+                try:
+                    return datetime.datetime.fromisoformat(value.replace('Z', '+00:00'))
+                except ValueError:
+                    continue
+        return datetime.datetime.min
+
+    def _get_latest_predict_tiled_entry(self, sample_uuid: str) -> Tuple[str, Any]:
+        entries = self._iter_predict_entries_for_sample(sample_uuid=sample_uuid)
+        entries_with_index = list(enumerate(entries))
+        latest = max(
+            entries_with_index,
+            key=lambda indexed: (
+                self._entry_sort_timestamp(indexed[1][1]),
+                indexed[0],
+            )
+        )
+        return latest[1]
+
+    def _extract_next_sample_from_tiled_entry(self, entry: Any, variable_name: str, entry_id: str) -> Dict[str, Any]:
+        try:
+            dataset = entry.read()
+        except Exception as exc:
+            error_msg = f"Failed to read tiled predict entry '{entry_id}': {exc}"
+            self.app.logger.error(error_msg)
+            raise ValueError(error_msg) from exc
+
+        if not isinstance(dataset, xr.Dataset):
+            error_msg = (
+                f"Predict tiled entry '{entry_id}' did not return an xarray.Dataset "
+                f"(got {type(dataset).__name__})."
+            )
+            self.app.logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        if variable_name not in dataset.data_vars:
+            error_msg = (
+                f"Predict tiled entry '{entry_id}' is missing data variable '{variable_name}'. "
+                f"Available variables: {list(dataset.data_vars.keys())}"
+            )
+            self.app.logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        variable = dataset[variable_name]
+        extracted = variable.to_pandas().squeeze()
+        if isinstance(extracted, dict):
+            return extracted
+        if hasattr(extracted, 'to_dict'):
+            extracted = extracted.to_dict()
+        if not isinstance(extracted, dict):
+            error_msg = (
+                f"Could not convert '{variable_name}' in tiled entry '{entry_id}' to dict; "
+                f"got {type(extracted).__name__}."
+            )
+            self.app.logger.error(error_msg)
+            raise ValueError(error_msg)
+        return extracted
 
     def make_and_measure(
             self,

--- a/test/test_orchestrator.py
+++ b/test/test_orchestrator.py
@@ -14,6 +14,7 @@ import json
 import tempfile
 import pathlib
 from unittest.mock import Mock, patch, MagicMock
+import xarray as xr
 
 from AFL.automation.orchestrator.OrchestratorDriver import OrchestratorDriver
 
@@ -379,6 +380,215 @@ class TestOrchestratorDriverDefaults:
     def test_default_composition_format_is_mass_fraction(self):
         """Test that composition_format defaults to mass_fraction"""
         assert OrchestratorDriver.defaults['composition_format'] == 'mass_fraction'
+
+    def test_default_next_samples_variable(self):
+        """Test that next_samples_variable defaults to next_samples"""
+        assert OrchestratorDriver.defaults['next_samples_variable'] == 'next_samples'
+
+
+class _FakeTiledResults:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def search(self, query):
+        key = query.key
+        value = query.value
+        filtered = {}
+        for entry_id, entry in self._entries.items():
+            metadata = dict(getattr(entry, 'metadata', {}) or {})
+            current = metadata
+            found = True
+            for part in key.split('.'):
+                if not isinstance(current, dict) or part not in current:
+                    found = False
+                    break
+                current = current[part]
+            if found and current == value:
+                filtered[entry_id] = entry
+        return _FakeTiledResults(filtered)
+
+    def items(self):
+        return list(self._entries.items())
+
+
+class _FakeTiledEntry:
+    def __init__(self, metadata, dataset):
+        self.metadata = metadata
+        self._dataset = dataset
+
+    def read(self):
+        return self._dataset
+
+
+class TestOrchestratorDriverPredictFromTiled:
+    def _driver_with_minimal_config(self):
+        driver = OrchestratorDriver(overrides={
+            'client': {
+                'load': 'localhost:5000',
+                'prep': 'localhost:5001',
+                'agent': 'localhost:5002',
+            },
+            'instrument': [
+                {
+                    'name': 'inst1',
+                    'client_name': 'inst_client',
+                    'measure_base_kw': {},
+                    'empty_base_kw': {},
+                    'concat_dim': 'sample',
+                }
+            ],
+            'ternary': False,
+            'data_tag': 'test',
+            'components': [],
+            'AL_components': [],
+            'snapshot_directory': '/tmp',
+            'max_sample_transmission': 0.6,
+            'mix_order': [],
+            'camera_urls': [],
+            'composition_format': 'mass_fraction',
+            'next_samples_variable': 'next_samples',
+        })
+        driver.app = Mock()
+        driver.app.logger = Mock()
+        return driver
+
+    def test_get_latest_predict_entry_matches_sample_uuid(self):
+        driver = self._driver_with_minimal_config()
+        ds = xr.Dataset({'next_samples': ('component', [1.0])}, coords={'component': ['A']})
+        entry = _FakeTiledEntry(
+            metadata={
+                'sample_uuid': 'SAM-123',
+                'task_name': 'predict',
+                'meta': {'ended': '2026-02-28T01:00:00'},
+            },
+            dataset=ds,
+        )
+        driver.data = Mock()
+        driver.data.tiled_client = _FakeTiledResults({'entry-1': entry})
+
+        entry_id, returned_entry = driver._get_latest_predict_tiled_entry(sample_uuid='SAM-123')
+        assert entry_id == 'entry-1'
+        assert returned_entry is entry
+
+    def test_get_latest_predict_entry_matches_attrs_sample_uuid(self):
+        driver = self._driver_with_minimal_config()
+        ds = xr.Dataset({'next_samples': ('component', [2.0])}, coords={'component': ['B']})
+        entry = _FakeTiledEntry(
+            metadata={
+                'attrs': {
+                    'sample_uuid': 'SAM-456',
+                    'task_name': 'predict',
+                    'meta': {'ended': '2026-02-28T01:01:00'},
+                }
+            },
+            dataset=ds,
+        )
+        driver.data = Mock()
+        driver.data.tiled_client = _FakeTiledResults({'entry-2': entry})
+
+        entry_id, returned_entry = driver._get_latest_predict_tiled_entry(sample_uuid='SAM-456')
+        assert entry_id == 'entry-2'
+        assert returned_entry is entry
+
+    def test_process_sample_enqueue_next_uses_tiled_and_not_retrieve_obj(self):
+        driver = self._driver_with_minimal_config()
+        driver.data = Mock()
+        ds = xr.Dataset(
+            {'next_samples': ('component', [1.2, 3.4])},
+            coords={'component': ['comp_a', 'comp_b']}
+        )
+        entry = _FakeTiledEntry(
+            metadata={
+                'sample_uuid': 'SAM-XYZ',
+                'task_name': 'predict',
+                'meta': {'ended': '2026-02-28T01:02:00'},
+            },
+            dataset=ds,
+        )
+        driver.data.tiled_client = _FakeTiledResults({'entry-3': entry})
+
+        agent_client = Mock()
+        agent_client.enqueue.return_value = {'return_val': 'AGENT-UUID'}
+        agent_client.retrieve_obj.side_effect = AssertionError("retrieve_obj should not be called")
+
+        driver.get_client = Mock(return_value=agent_client)
+        driver.make_and_measure = Mock()
+        driver.validate_config = Mock()
+        driver._queue = Mock()
+        driver._queue.qsize.return_value = 0
+
+        driver.process_sample(
+            sample={},
+            predict_next=True,
+            enqueue_next=True,
+            sample_uuid='SAM-XYZ',
+            AL_uuid='AL-XYZ',
+            AL_campaign_name='camp',
+        )
+
+        assert driver._queue.put.call_count == 1
+        queued_package, _ = driver._queue.put.call_args[0]
+        assert queued_package['task']['task_name'] == 'process_sample'
+        concentrations = queued_package['task']['sample']['concentrations']
+        assert concentrations['comp_a'] == '1.2 mg/ml'
+        assert concentrations['comp_b'] == '3.4 mg/ml'
+
+    def test_process_sample_enqueue_next_raises_when_tiled_entry_missing(self):
+        driver = self._driver_with_minimal_config()
+        driver.data = Mock()
+        driver.data.tiled_client = _FakeTiledResults({})
+
+        agent_client = Mock()
+        agent_client.enqueue.return_value = {'return_val': 'AGENT-UUID'}
+
+        driver.get_client = Mock(return_value=agent_client)
+        driver.make_and_measure = Mock()
+        driver.validate_config = Mock()
+        driver._queue = Mock()
+        driver._queue.qsize.return_value = 0
+
+        with pytest.raises(ValueError):
+            driver.process_sample(
+                sample={},
+                predict_next=True,
+                enqueue_next=True,
+                sample_uuid='SAM-MISSING',
+                AL_uuid='AL-XYZ',
+                AL_campaign_name='camp',
+            )
+
+    def test_process_sample_enqueue_next_raises_when_variable_missing(self):
+        driver = self._driver_with_minimal_config()
+        driver.data = Mock()
+        ds = xr.Dataset({'not_next_samples': ('component', [5.0])}, coords={'component': ['comp_a']})
+        entry = _FakeTiledEntry(
+            metadata={
+                'sample_uuid': 'SAM-ABC',
+                'task_name': 'predict',
+                'meta': {'ended': '2026-02-28T01:05:00'},
+            },
+            dataset=ds,
+        )
+        driver.data.tiled_client = _FakeTiledResults({'entry-4': entry})
+
+        agent_client = Mock()
+        agent_client.enqueue.return_value = {'return_val': 'AGENT-UUID'}
+
+        driver.get_client = Mock(return_value=agent_client)
+        driver.make_and_measure = Mock()
+        driver.validate_config = Mock()
+        driver._queue = Mock()
+        driver._queue.qsize.return_value = 0
+
+        with pytest.raises(ValueError):
+            driver.process_sample(
+                sample={},
+                predict_next=True,
+                enqueue_next=True,
+                sample_uuid='SAM-ABC',
+                AL_uuid='AL-XYZ',
+                AL_campaign_name='camp',
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request refactors how the `OrchestratorDriver` retrieves and handles "next sample" predictions, moving from direct agent client calls to querying Tiled entries for prediction results. It introduces robust utilities for extracting prediction data from Tiled, supports flexible metadata key paths, and adds comprehensive tests for the new logic.

Key changes include:

### Refactoring prediction retrieval in `OrchestratorDriver`

* Replaces the use of `retrieve_obj` on the agent client with a new workflow that queries Tiled for the latest "predict" entry associated with a sample UUID, extracting the next sample from the returned xarray dataset. This is more robust and decouples the orchestrator from direct agent state.
* Adds a new default config key, `next_samples_variable`, to specify which variable in the dataset to extract for the next sample.
* Introduces helper methods: `_iter_predict_entries_for_sample`, `_entry_sort_timestamp`, `_get_latest_predict_tiled_entry`, and `_extract_next_sample_from_tiled_entry` for searching, sorting, and extracting data from Tiled entries, supporting multiple possible metadata key paths and robust error handling.

### Type and import improvements

* Expands type imports to include `Any` and `Tuple` for type annotations in new helper methods.

### Testing enhancements

* Adds extensive new tests to `test_orchestrator.py` to validate the new Tiled-based prediction retrieval logic, including tests for variable extraction, error handling when entries or variables are missing, and ensuring the agent client is no longer used for retrieving next samples. Introduces `_FakeTiledResults` and `_FakeTiledEntry` test helpers.
* Adds a test for the new `next_samples_variable` default.
* Adds `xarray` import for dataset handling in tests.