### PR TITLE
Add upload composition section with dynamic row management for dataset uploads

### DIFF
--- a/AFL/automation/apps/tiled_browser/css/tiled_browser.css
+++ b/AFL/automation/apps/tiled_browser/css/tiled_browser.css
@@ -429,6 +429,97 @@ body {
     gap: 8px;
 }
 
+.upload-composition-section {
+    border: 1px solid #e3e7eb;
+    border-radius: 6px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background-color: #fafcfd;
+}
+
+.upload-composition-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #555;
+}
+
+#upload-add-composition-button {
+    padding: 6px 12px;
+    border: 1px solid #cfd8dc;
+    border-radius: 4px;
+    background-color: #fff;
+    color: #0b7285;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+#upload-add-composition-button:hover {
+    background-color: #f1f6f8;
+}
+
+#upload-composition-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.upload-composition-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: center;
+}
+
+.upload-composition-row input {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.upload-composition-row input:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+}
+
+.upload-composition-remove {
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background-color: #e74c3c;
+    color: #fff;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.upload-composition-remove:hover {
+    background-color: #c0392b;
+}
+
+@media (max-width: 900px) {
+    .upload-composition-row {
+        grid-template-columns: 1fr;
+    }
+
+    .upload-composition-remove {
+        width: 100%;
+        height: auto;
+        padding: 8px 10px;
+        font-size: 14px;
+    }
+}
+
 #upload-submit-button {
     padding: 10px 20px;
     border: none;

--- a/AFL/automation/apps/tiled_browser/js/tiled_browser.js
+++ b/AFL/automation/apps/tiled_browser/js/tiled_browser.js
@@ -19,6 +19,7 @@ let totalCount = 0;
 let multiSelectInstances = {};  // Store multi-select state for each filter
 let currentCopyText = '';
 let uploadColumnHeaders = [];
+let lastUploadFormState = null;
 const DEFAULT_SORT_MODEL = [{ colId: 'meta_ended', sort: 'desc' }];
 
 // Available search fields (excluding datetime columns)
@@ -1407,8 +1408,149 @@ async function handleUploadFileSelection() {
     }
 }
 
-function gatherUploadMetadata() {
+function isNumericUploadCompositionValue(value) {
+    return /^[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/.test(value);
+}
+
+function createUploadCompositionRow(component = '', value = '') {
+    const row = document.createElement('div');
+    row.className = 'upload-composition-row';
+
+    const componentInput = document.createElement('input');
+    componentInput.type = 'text';
+    componentInput.className = 'upload-composition-component';
+    componentInput.placeholder = 'Component name (e.g. PEG)';
+    componentInput.value = component;
+
+    const valueInput = document.createElement('input');
+    valueInput.type = 'text';
+    valueInput.className = 'upload-composition-value';
+    valueInput.placeholder = 'Value (e.g. 0.35)';
+    valueInput.value = value;
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'upload-composition-remove';
+    removeBtn.textContent = 'x';
+    removeBtn.title = 'Remove component row';
+    removeBtn.addEventListener('click', () => {
+        row.remove();
+    });
+
+    row.appendChild(componentInput);
+    row.appendChild(valueInput);
+    row.appendChild(removeBtn);
+    return row;
+}
+
+function initializeUploadCompositionEditor() {
+    const rowsContainer = document.getElementById('upload-composition-rows');
+    const addButton = document.getElementById('upload-add-composition-button');
+    if (!rowsContainer || !addButton) {
+        return;
+    }
+
+    addButton.addEventListener('click', () => {
+        rowsContainer.appendChild(createUploadCompositionRow());
+    });
+
+    if (!rowsContainer.children.length) {
+        rowsContainer.appendChild(createUploadCompositionRow());
+    }
+}
+
+function getUploadCompositionRows() {
+    return Array.from(document.querySelectorAll('#upload-composition-rows .upload-composition-row'));
+}
+
+function gatherSampleComposition() {
+    const composition = {};
+    const rows = getUploadCompositionRows();
+
+    for (const row of rows) {
+        const compInput = row.querySelector('.upload-composition-component');
+        const valueInput = row.querySelector('.upload-composition-value');
+        const compName = compInput ? compInput.value.trim() : '';
+        const rawValue = valueInput ? valueInput.value.trim() : '';
+
+        if (!compName && !rawValue) {
+            continue;
+        }
+        if (!compName || !rawValue) {
+            throw new Error('Each sample composition row needs both component name and value.');
+        }
+
+        composition[compName] = isNumericUploadCompositionValue(rawValue) ? Number(rawValue) : rawValue;
+    }
+
+    return composition;
+}
+
+function getUploadFormState() {
+    const rows = getUploadCompositionRows().map(row => ({
+        component: (row.querySelector('.upload-composition-component')?.value || '').trim(),
+        value: (row.querySelector('.upload-composition-value')?.value || '').trim()
+    }));
+
     return {
+        delimiter: document.getElementById('upload-delimiter').value,
+        coordinate_column: document.getElementById('upload-coordinate-column').value,
+        sample_name: document.getElementById('upload-sample-name').value,
+        sample_uuid: document.getElementById('upload-sample-uuid').value,
+        AL_campaign_name: document.getElementById('upload-al-campaign-name').value,
+        AL_uuid: document.getElementById('upload-al-uuid').value,
+        task_name: document.getElementById('upload-task-name').value,
+        driver_name: document.getElementById('upload-driver-name').value,
+        composition_rows: rows
+    };
+}
+
+function restoreUploadFormState(state) {
+    if (!state || typeof state !== 'object') {
+        return;
+    }
+
+    const byId = {
+        'upload-delimiter': state.delimiter,
+        'upload-sample-name': state.sample_name,
+        'upload-sample-uuid': state.sample_uuid,
+        'upload-al-campaign-name': state.AL_campaign_name,
+        'upload-al-uuid': state.AL_uuid,
+        'upload-task-name': state.task_name,
+        'upload-driver-name': state.driver_name
+    };
+
+    Object.entries(byId).forEach(([id, value]) => {
+        const el = document.getElementById(id);
+        if (el && value !== undefined && value !== null) {
+            el.value = value;
+        }
+    });
+
+    const coordEl = document.getElementById('upload-coordinate-column');
+    if (coordEl && state.coordinate_column) {
+        const option = Array.from(coordEl.options).find(opt => opt.value === state.coordinate_column);
+        if (option) {
+            coordEl.value = state.coordinate_column;
+        }
+    }
+
+    const rowsContainer = document.getElementById('upload-composition-rows');
+    if (rowsContainer) {
+        rowsContainer.innerHTML = '';
+        const rows = Array.isArray(state.composition_rows) ? state.composition_rows : [];
+        if (rows.length) {
+            rows.forEach(row => {
+                rowsContainer.appendChild(createUploadCompositionRow(row.component || '', row.value || ''));
+            });
+        } else {
+            rowsContainer.appendChild(createUploadCompositionRow());
+        }
+    }
+}
+
+function gatherUploadMetadata() {
+    const metadata = {
         sample_name: document.getElementById('upload-sample-name').value.trim(),
         sample_uuid: document.getElementById('upload-sample-uuid').value.trim(),
         AL_campaign_name: document.getElementById('upload-al-campaign-name').value.trim(),
@@ -1416,14 +1558,21 @@ function gatherUploadMetadata() {
         task_name: document.getElementById('upload-task-name').value.trim(),
         driver_name: document.getElementById('upload-driver-name').value.trim()
     };
+
+    const sampleComposition = gatherSampleComposition();
+    if (Object.keys(sampleComposition).length > 0) {
+        metadata.sample_composition = sampleComposition;
+    }
+
+    return metadata;
 }
 
 async function submitDatasetUpload() {
     const fileInput = document.getElementById('upload-file-input');
     const uploadBtn = document.getElementById('upload-submit-button');
-    const formatEl = document.getElementById('upload-file-format');
     const delimiterEl = document.getElementById('upload-delimiter');
     const coordEl = document.getElementById('upload-coordinate-column');
+    lastUploadFormState = getUploadFormState();
 
     if (!fileInput || !fileInput.files || fileInput.files.length === 0) {
         showError('Please choose a file to upload.');
@@ -1442,7 +1591,13 @@ async function submitDatasetUpload() {
         return;
     }
 
-    const metadata = gatherUploadMetadata();
+    let metadata;
+    try {
+        metadata = gatherUploadMetadata();
+    } catch (error) {
+        showError(error.message);
+        return;
+    }
     const payload = new FormData();
     payload.append('file', file);
     payload.append('file_format', format);
@@ -1485,6 +1640,7 @@ async function submitDatasetUpload() {
     } finally {
         uploadBtn.disabled = false;
         uploadBtn.textContent = originalText;
+        restoreUploadFormState(lastUploadFormState);
     }
 }
 
@@ -1586,6 +1742,8 @@ function setupEventListeners() {
     const uploadFileInput = document.getElementById('upload-file-input');
     const uploadDelimiter = document.getElementById('upload-delimiter');
     const uploadSubmitButton = document.getElementById('upload-submit-button');
+    initializeUploadCompositionEditor();
+
     if (uploadFileInput) {
         uploadFileInput.addEventListener('change', handleUploadFileSelection);
     }

--- a/AFL/automation/apps/tiled_browser/tiled_browser.html
+++ b/AFL/automation/apps/tiled_browser/tiled_browser.html
@@ -160,8 +160,15 @@
                                 <input id="upload-driver-name" type="text" value="manual_upload">
                             </div>
                         </div>
+                        <div class="upload-composition-section">
+                            <div class="upload-composition-header">
+                                <span>Sample Composition <span class="field-note">(Optional; saved to attrs.sample_composition)</span></span>
+                                <button id="upload-add-composition-button" type="button">+ Add Component</button>
+                            </div>
+                            <div id="upload-composition-rows"></div>
+                        </div>
                         <div class="upload-buttons">
-                            <button id="upload-submit-button">Upload Dataset</button>
+                            <button id="upload-submit-button" type="button">Upload Dataset</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This pull request introduces a new "Sample Composition" editor to the dataset upload form in the Tiled Browser app. Users can now add, edit, and remove chemical composition components as part of the upload process, with an improved UI and client-side validation. The implementation includes new HTML elements, CSS styles, and JavaScript logic for managing the composition rows and persisting form state.

**New "Sample Composition" Editor Feature:**

* Added a new section to the upload form in `tiled_browser.html` for entering sample composition, allowing users to dynamically add or remove component rows, each with a component name and value. This data is saved to `attrs.sample_composition` if provided.
* Implemented new CSS styles in `tiled_browser.css` for the composition editor, including responsive layout, input styling, and button appearance for a clean and user-friendly interface.

**JavaScript Logic and State Management:**

* Introduced new functions in `tiled_browser.js` to create, initialize, and manage the composition rows, including validation to ensure both component name and value are provided, and support for numeric values.
* Enhanced the upload workflow to gather the composition data as part of the metadata, with error handling for incomplete rows, and restored form state after upload attempts for a better user experience. [[1]](diffhunk://#diff-c0173bd273a72531fbeaf02df484ba784da274e6274a6b1ab7348154727aa6dbL1410-R1575) [[2]](diffhunk://#diff-c0173bd273a72531fbeaf02df484ba784da274e6274a6b1ab7348154727aa6dbL1445-R1600) [[3]](diffhunk://#diff-c0173bd273a72531fbeaf02df484ba784da274e6274a6b1ab7348154727aa6dbR1643)
* Ensured the composition editor is initialized when the page loads by updating the event listener setup.

These changes collectively improve the flexibility and usability of the dataset upload process, particularly for scientific data requiring detailed sample composition metadata.